### PR TITLE
Update MatrixFireFast.ino

### DIFF
--- a/MatrixFireFast/MatrixFireFast.ino
+++ b/MatrixFireFast/MatrixFireFast.ino
@@ -255,7 +255,7 @@ void make_fire() {
 }
 
 void setup() {
-  FastLED.addLeds<MAT_TYPE, MAT_PIN>(matrix, MAT_W * MAT_H);
+  FastLED.addLeds<MAT_TYPE, MAT_PIN>(matrix, (MAT_H * PANELS_H * MAT_W * PANELS_W));
   FastLED.setBrightness(BRIGHT);
   FastLED.clear();
   FastLED.show();


### PR DESCRIPTION
I found I needed to take account of the number of leds when multiple panels were used else only the first panel displayed output as only it's leds were initialised.