### PR TITLE
ESPHome integration

### DIFF
--- a/EspHome/MatrixFireFast.yaml
+++ b/EspHome/MatrixFireFast.yaml
@@ -8,7 +8,7 @@ light:
     name: MatrixFireFast
     effects:
       - addressable_lambda:
-          name: Fire
+          name: MatrixFireFast
           update_interval: 70ms
           lambda: |-
             const bool colmajor = false;

--- a/EspHome/MatrixFireFast.yaml
+++ b/EspHome/MatrixFireFast.yaml
@@ -1,0 +1,150 @@
+light:
+  - platform: fastled_clockless
+    chipset: WS2811
+    pin: GPIO13
+    num_leds: 315
+    rgb_order: GRB
+    id: matrixfirefast
+    name: MatrixFireFast
+    effects:
+      - addressable_lambda:
+          name: Fire
+          update_interval: 70ms
+          lambda: |-
+            const bool colmajor = false;
+            const bool mattop = true;
+            const bool matleft = true;
+            const bool zigzag = true;
+            const uint16_t rows = 15;
+            const uint16_t cols = 21;
+            const uint16_t offsetx = 0;
+            const uint16_t offsety = 0;
+            const uint8_t maxflare = 3;
+            const uint8_t flarerows = 7;
+            const uint8_t flarechance = 30;
+            const uint8_t flaredecay = 14;
+            const uint32_t colors[] = {0x000000,0x100000,0x300000,0x600000,0x800000,0xA00000,0xC02000,0xC04000,0xC06000,0xC08000,0x807080};
+            const uint8_t NCOLORS = (sizeof(colors)/sizeof(colors[0]));
+
+            static uint8_t nflare = 0;
+            static uint32_t flare[maxflare];
+            static uint8_t pix[rows][cols];
+            static bool needsinit = true;
+            static long t = 0;
+            
+            uint16_t b, d, i, j, k, l, n, x, y, z;
+            uint16_t phy_w = cols;
+            uint16_t phy_h = rows;
+            uint16_t phy_x = 0;
+            uint16_t phy_y = 0;
+            
+            
+            if ( needsinit == true ) {
+              needsinit = false;
+              for ( i=0; i<rows; ++i ) {
+                for ( j=0; j<cols; ++j ) {
+                  if ( i == 0 ) pix[i][j] = NCOLORS - 1;
+                  else pix[i][j] = 0;
+                }
+              }
+            }
+            
+            // First, move all existing heat points up the display and fade
+            for ( i=rows-1; i>0; --i ) {
+              for ( j=0; j<cols; ++j ) {
+                uint8_t n = 0;
+                if ( pix[i-1][j] > 0 )
+                  n = pix[i-1][j] - 1;
+                pix[i][j] = n;
+              }
+            }
+          
+            // Heat the bottom row
+            for ( j=0; j<cols; ++j ) {
+              i = pix[0][j];
+              if ( i > 0 ) {
+                pix[0][j] = random(NCOLORS-6, NCOLORS-2);
+              }
+            }
+
+            // Update existing flares
+            for ( i=0; i<nflare; ++i ) {
+              x = flare[i] & 0xff;
+              y = (flare[i] >> 8) & 0xff;
+              z = (flare[i] >> 16) & 0xff;
+              b = z * 10 / flaredecay + 1;
+              for ( k=(y-b); k<(y+b); ++k ) {
+                for ( int l=(x-b); l<(x+b); ++l ) {
+                  if ( k >=0 && l >= 0 && k < rows && l < cols ) {
+                    d = ( flaredecay * sqrt16((x-l)*(x-l) + (y-k)*(y-k)) + 5 ) / 10;
+                    n = 0;
+                    if ( z > d ) n = z - d;
+                    if ( n > pix[k][l] ) { // can only get brighter
+                      pix[k][l] = n;
+                    }
+                  }
+                }
+              }
+              if ( z > 1 ) {
+                flare[i] = (flare[i] & 0xffff) | ((z-1)<<16);
+              } else {
+                // This flare is out
+                for ( j=i+1; j<nflare; ++j ) {
+                  flare[j-1] = flare[j];
+                }
+                --nflare;
+              }
+            }
+            // New Flare
+            if ( nflare < maxflare && random(1,101) <= flarechance ) {
+              x = random(0, cols);
+              y = random(0, flarerows);
+              z = NCOLORS - 1;
+              b = z * 10 / flaredecay + 1;
+              flare[nflare++] = (z<<16) | (y<<8) | (x&0xff);
+              for ( k=(y-b); k<(y+b); ++k ) {
+                for ( int l=(x-b); l<(x+b); ++l ) {
+                  if ( k >=0 && l >= 0 && k < rows && l < cols ) {
+                    d = ( flaredecay * sqrt16((x-l)*(x-l) + (y-k)*(y-k)) + 5 ) / 10;
+                    n = 0;
+                    if ( z > d ) n = z - d;
+                    if ( n > pix[k][l] ) { // can only get brighter
+                      pix[k][l] = n;
+                    }
+                  }
+                }
+              }
+            }
+            // Draw
+            if ( colmajor == true ) {
+              phy_w = rows;
+              phy_h = cols;
+            }
+            for ( uint16_t row=0; row<rows; ++row ) {
+              for ( uint16_t col=0; col<cols; ++col ) {
+                if ( colmajor == true ) {
+                    phy_x = offsetx + (uint16_t) row;
+                    phy_y = offsety + (uint16_t) col;
+                } else {
+                    phy_x = offsetx + (uint16_t) col;
+                    phy_y = offsety + (uint16_t) row;
+                }
+                if ( matleft == true && zigzag == true ) {
+                  if ( ( phy_y & 1 ) == 1 ) {
+                    phy_x = phy_w - phy_x - 1;
+                  }
+                } else if ( matleft == false && zigzag == true ) {
+                  if ( ( phy_y & 1 ) == 0 ) {
+                    phy_x = phy_w - phy_x - 1;
+                  }
+                } else if ( matleft == false ) {
+                  phy_x = phy_w - phy_x - 1;
+                }
+                if ( mattop == true && colmajor == true ) {
+                  phy_x = phy_w - phy_x - 1;
+                } else if (mattop) {
+                  phy_y = phy_h - phy_y - 1;
+                }
+                it[phy_x + phy_y * phy_w] = ESPColor(colors[pix[row][col]]);
+              }
+            }


### PR DESCRIPTION
Added ESPHome support through the fastled_clockless light platform:
- Conversion to lambda custom effect
- Rewrite to single main function for easy implementation through the ESPHome GUI

Instructions:
- Copy/paste contents of EspHome/MatrixFireFast.yaml in ESPHome device config
- Change relevant settings (pin number, num_leds,...) according to chipset and preference

Notes:
- Tested on latest ESPHome v2021.12.1 on ESP32 WROOM using a home made WS2811 21*15 matrix
- Multipanel support not implemented as no means to test this at the moment
- Replaced isqrt function with built-in fastled sqrt16 to be able to stick to a single main function
- For the same reason, the glow function code is repeated when creating new flare
- My C++ knowledge is very rusty and based on what remains from classes 20 years ago, so chances are high the code can be optimized :)